### PR TITLE
Fixes "Unknown Skill" Issues

### DIFF
--- a/Loki/Skill.cs
+++ b/Loki/Skill.cs
@@ -43,6 +43,7 @@ namespace Loki
                     SkillType.Ride => Properties.Resources.Riding,
                     SkillType.All => Properties.Resources.All,
                     //_ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unrecognised skill type"),
+                    _ => Properties.Resources.Unknown,
                 };
 
         public SkillType Type { get; }

--- a/Loki/Skill.cs
+++ b/Loki/Skill.cs
@@ -42,7 +42,7 @@ namespace Loki
                     SkillType.Swim => Properties.Resources.Swim,
                     SkillType.Ride => Properties.Resources.Riding,
                     SkillType.All => Properties.Resources.All,
-                    _ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unrecognised skill type"),
+                    //_ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unrecognised skill type"),
                 };
 
         public SkillType Type { get; }


### PR DESCRIPTION
Fixes the issue where mods that create their own skills break the program. This labels all added skills as "Unknown" allowing users to continue using the program as intended without having their mods break it.

Just comments out the throw and instead has anything in the "Default" part of the "Switch" mark it as "Unknown"