### PR TITLE
Fix of repair item issue

### DIFF
--- a/Loki/Item.cs
+++ b/Loki/Item.cs
@@ -103,6 +103,11 @@ namespace Loki
             {
                 Unrecognised = true;
             }
+            else
+            {                
+                // Force-calculating max durability initial value
+                MaxDurability = 1;
+            }
 
         }
 


### PR DESCRIPTION
Items with damage cannot be repaired: they were incorrectly shown as fully repaired.

Did this work at all to begin with? The property MaxDamage was never set (ie force calculated) initially from what I can see. Only when changing quality.