### PR TITLE
Support Mistlands update

### DIFF
--- a/Loki/InventorySlotEditor.xaml.cs
+++ b/Loki/InventorySlotEditor.xaml.cs
@@ -24,7 +24,7 @@ namespace Loki
             {
                 if (this.DataContext is InventorySlot slot)
                 {
-                    var customData = new Dictionary<String, String>();
+                    var customData = new List<(string, string)>();
                     slot.Item = new Item(itemData.ItemName, itemData.MaxStack, (float)itemData.MaxDurability, slot.Position,
                         false, 1, 0, MainWindow.selectedPlayerProfile.PlayerId, MainWindow.selectedPlayerProfile.PlayerName, customData);
                 }

--- a/Loki/InventorySlotEditor.xaml.cs
+++ b/Loki/InventorySlotEditor.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Controls;
@@ -23,8 +24,9 @@ namespace Loki
             {
                 if (this.DataContext is InventorySlot slot)
                 {
+                    var customData = new Dictionary<String, String>();
                     slot.Item = new Item(itemData.ItemName, itemData.MaxStack, (float)itemData.MaxDurability, slot.Position,
-                        false, 1, 0, MainWindow.selectedPlayerProfile.PlayerId, MainWindow.selectedPlayerProfile.PlayerName); ;
+                        false, 1, 0, MainWindow.selectedPlayerProfile.PlayerId, MainWindow.selectedPlayerProfile.PlayerName, customData);
                 }
             }
         }

--- a/Loki/Item.cs
+++ b/Loki/Item.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
@@ -79,7 +80,7 @@ namespace Loki
         public double MaxDurability => SharedData.MaxDurability + Math.Max(0, Quality - 1) * SharedData.DurabilityPerLevel;
   
 
-        public Item(string name, int stack, float durability, Vector2i pos, bool equiped, int quality, int variant, long crafterId, string crafterName)
+        public Item(string name, int stack, float durability, Vector2i pos, bool equiped, int quality, int variant, long crafterId, string crafterName, Dictionary<String, String> itemData)
         {
             Name = name;
             Stack = stack;
@@ -97,10 +98,13 @@ namespace Loki
                 Unrecognised = true;
             }
 
+            ItemData = itemData;
+
         }
 
         [CanBeNull] // Can be null if the item is unrecognised (very new update not accounted for etc.)
         public SharedItemData SharedData { get; }
+        public Dictionary<String, String> ItemData { get; }
 
         public bool HasQualityLevels => SharedData?.MaxQuality > 1;
 

--- a/Loki/Item.cs
+++ b/Loki/Item.cs
@@ -80,7 +80,7 @@ namespace Loki
         public double MaxDurability => SharedData.MaxDurability + Math.Max(0, Quality - 1) * SharedData.DurabilityPerLevel;
   
 
-        public Item(string name, int stack, float durability, Vector2i pos, bool equiped, int quality, int variant, long crafterId, string crafterName, Dictionary<String, String> itemData)
+        public Item(string name, int stack, float durability, Vector2i pos, bool equiped, int quality, int variant, long crafterId, string crafterName, List<(string, string)> itemData)
         {
             Name = name;
             Stack = stack;
@@ -104,7 +104,7 @@ namespace Loki
 
         [CanBeNull] // Can be null if the item is unrecognised (very new update not accounted for etc.)
         public SharedItemData SharedData { get; }
-        public Dictionary<String, String> ItemData { get; }
+        public List<(string, string)> ItemData { get; }
 
         public bool HasQualityLevels => SharedData?.MaxQuality > 1;
 

--- a/Loki/Player.cs
+++ b/Loki/Player.cs
@@ -350,8 +350,14 @@ namespace Loki
                 int variant = version >= 102 ? reader.ReadInt32() : 0;
                 (long crafterId, string crafterName) =
                     version >= 103 ? (reader.ReadInt64(), reader.ReadString()) : (0, string.Empty);
+                var itemData = new Dictionary<string, string>();
+                var itemDataCount = reader.ReadInt32();
+                for (int j = 0; j < itemDataCount; j++)
+                {
+                    itemData.Add(reader.ReadString(), reader.ReadString());
+                }
                 Debug.WriteLine($"ReadInv: Item={name}, Position={pos}");
-                if(name != "") items.Add(new Item(name, stack, durability, pos, equiped, quality, variant, crafterId, crafterName));
+                if(name != "") items.Add(new Item(name, stack, durability, pos, equiped, quality, variant, crafterId, crafterName, itemData));
             }
             return items;
         }

--- a/Loki/Player.cs
+++ b/Loki/Player.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Windows;
+using System.Windows.Markup;
 using System.Windows.Media;
 using JetBrains.Annotations;
 
@@ -39,9 +40,13 @@ namespace Loki
         private string _hair;
         private Vector3 _skinColour;
         private Vector3 _hairColour;
+        private float _stamina;
+        private float _maxEitr;
+        private float _eitr;
 
         private int _modelIndex;
         private readonly List<Food> _food = new List<Food>();
+        private Dictionary<String, String> customPlayerData = new Dictionary<String, String>();
         public ObservableCollection<Skill> Skills { get; } = new ObservableCollection<Skill>();
 
         public Inventory Inventory { get; } = new Inventory(8, 4);
@@ -235,13 +240,12 @@ namespace Loki
                 var customDataCount = reader.ReadInt32();
                 for (int i = 0; i < customDataCount; i++)
                 {
-                    reader.ReadString();
-                    reader.ReadString();
+                    player.customPlayerData.Add(reader.ReadString(), reader.ReadString());
                 }
 
-                var stamina = reader.ReadSingle();
-                var maxEitr = reader.ReadSingle();
-                var eitr = reader.ReadSingle();
+                player._stamina = reader.ReadSingle();
+                player._maxEitr = reader.ReadSingle();
+                player._eitr = reader.ReadSingle();
             }
 
             // Sanity check - compare with player data length provided.

--- a/Loki/Player.cs
+++ b/Loki/Player.cs
@@ -16,8 +16,8 @@ namespace Loki
 {
     public class Player: INotifyPropertyChanged
     {
-        private const int Version = 25;
-        private const int InventoryVersion = 103;
+        private const int Version = 26;
+        private const int InventoryVersion = 104;
         private const int SkillVersion = 2;
 
         private float _maxHealth;

--- a/Loki/Player.cs
+++ b/Loki/Player.cs
@@ -46,7 +46,7 @@ namespace Loki
 
         private int _modelIndex;
         private readonly List<Food> _food = new List<Food>();
-        private Dictionary<String, String> customPlayerData = new Dictionary<String, String>();
+        private readonly List<(string, string)> customPlayerData = new List<(string, string)>();
         public ObservableCollection<Skill> Skills { get; } = new ObservableCollection<Skill>();
 
         public Inventory Inventory { get; } = new Inventory(8, 4);
@@ -240,7 +240,7 @@ namespace Loki
                 var customDataCount = reader.ReadInt32();
                 for (int i = 0; i < customDataCount; i++)
                 {
-                    player.customPlayerData.Add(reader.ReadString(), reader.ReadString());
+                    player.customPlayerData.Add((reader.ReadString(), reader.ReadString()));
                 }
 
                 player._stamina = reader.ReadSingle();
@@ -369,11 +369,11 @@ namespace Loki
                 int variant = version >= 102 ? reader.ReadInt32() : 0;
                 (long crafterId, string crafterName) =
                     version >= 103 ? (reader.ReadInt64(), reader.ReadString()) : (0, string.Empty);
-                var itemData = new Dictionary<string, string>();
+                var itemData = new List<(string, string)>();
                 var itemDataCount = reader.ReadInt32();
                 for (int j = 0; j < itemDataCount; j++)
                 {
-                    itemData.Add(reader.ReadString(), reader.ReadString());
+                    itemData.Add((reader.ReadString(), reader.ReadString()));
                 }
                 Debug.WriteLine($"ReadInv: Item={name}, Position={pos}");
                 if(name != "") items.Add(new Item(name, stack, durability, pos, equiped, quality, variant, crafterId, crafterName, itemData));

--- a/Loki/Player.cs
+++ b/Loki/Player.cs
@@ -387,10 +387,13 @@ namespace Loki
                 (long crafterId, string crafterName) =
                     version >= 103 ? (reader.ReadInt64(), reader.ReadString()) : (0, string.Empty);
                 var itemData = new List<(string, string)>();
-                var itemDataCount = reader.ReadInt32();
-                for (int j = 0; j < itemDataCount; j++)
+                if (version >= 104)
                 {
-                    itemData.Add((reader.ReadString(), reader.ReadString()));
+                    var itemDataCount = reader.ReadInt32();
+                    for (int j = 0; j < itemDataCount; j++)
+                    {
+                        itemData.Add((reader.ReadString(), reader.ReadString()));
+                    }
                 }
                 Debug.WriteLine($"ReadInv: Item={name}, Position={pos}");
                 if(name != "") items.Add(new Item(name, stack, durability, pos, equiped, quality, variant, crafterId, crafterName, itemData));

--- a/Loki/Player.cs
+++ b/Loki/Player.cs
@@ -237,7 +237,6 @@ namespace Loki
 
             if (version >= 26)
             {
-                // TODO: Actually save these
                 var customDataCount = reader.ReadInt32();
                 for (int i = 0; i < customDataCount; i++)
                 {

--- a/Loki/Player.cs
+++ b/Loki/Player.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -309,6 +310,13 @@ namespace Loki
                 writer.Write(item.Variant);
                 writer.Write(item.CrafterId);
                 writer.Write(item.CrafterName);
+                writer.Write(item.ItemData.Count);
+                foreach (var customData in item.ItemData)
+                {
+                    var (key, value) = customData;
+                    writer.Write(key);
+                    writer.Write(value);
+                }
             }
 
             writer.WriteCountItems(_knownRecipes);
@@ -350,6 +358,18 @@ namespace Loki
                 writer.Write(skill.Level);
                 writer.Write(skill.Accumulator);
             }
+
+            writer.Write(customPlayerData.Count);
+            foreach (var customData in customPlayerData)
+            {
+                var (key, value) = customData;
+                writer.Write(key);
+                writer.Write(value);
+            }
+
+            writer.Write(_stamina);
+            writer.Write(_maxEitr);
+            writer.Write(_eitr);
         }
 
         private static List<Item> ReadInventory(Stream input, bool leaveOpen = false)

--- a/Loki/Player.cs
+++ b/Loki/Player.cs
@@ -229,6 +229,21 @@ namespace Loki
                 }
             }
 
+            if (version >= 26)
+            {
+                // TODO: Actually save these
+                var customDataCount = reader.ReadInt32();
+                for (int i = 0; i < customDataCount; i++)
+                {
+                    reader.ReadString();
+                    reader.ReadString();
+                }
+
+                var stamina = reader.ReadSingle();
+                var maxEitr = reader.ReadSingle();
+                var eitr = reader.ReadSingle();
+            }
+
             // Sanity check - compare with player data length provided.
             long amountRead = input.Position - playerDataStartPos;
             if (amountRead != expectedPlayerDataLength)

--- a/Loki/Player.cs
+++ b/Loki/Player.cs
@@ -2,14 +2,12 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Windows;
-using System.Windows.Markup;
 using System.Windows.Media;
 using JetBrains.Annotations;
 

--- a/Loki/Version.cs
+++ b/Loki/Version.cs
@@ -8,13 +8,14 @@ namespace Loki
         /// <summary>
         /// Version of PlayerProfile .fch data. This is the version of the saved file.
         /// </summary>
-        public const int ProfileVersion = 36;
+        public const int ProfileVersion = 37;
 
         /// <summary>
         /// These legacy versions are also considered compatible, in addition to <see cref="ProfileVersion"/>
         /// </summary>
         private static readonly int[] CompatibleProfileVersions =
         {
+            36,
             35,
             34,
             33,


### PR DESCRIPTION
Adds support for format 37 used in the Mistlands public beta.

- inventory version 104 adds a new custom data dictionary to all inventory items.
- player version 26 adds new custom data dictionary as well as fields for stamina, maxEitr and eitr.

I have tested this personally but I have not yet seen any items with custom data, neither have I progressed far enough in the game to unlock the new Eitr mechanic so that is untested but at least this lets you open and save "normal" profiles.

There are also lots of new items in the Mistlands updated but I've not made any attempt to update the SharedData tables.