### PR TITLE
Feature: Move project to .NET 7

### DIFF
--- a/Loki/Loki.csproj
+++ b/Loki/Loki.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>Adam Rhodes</Authors>
     <Company>TwoThreeSix</Company>


### PR DESCRIPTION
- Changed target framework to .NET 7.
- Changed project file root to remove warning, ref: https://learn.microsoft.com/en-us/dotnet/core/tools/sdk-errors/netsdk1137