### PR TITLE
Update Item.cs

### DIFF
--- a/Loki/Item.cs
+++ b/Loki/Item.cs
@@ -77,7 +77,7 @@ namespace Loki
 
         public bool HasCrafterTag => CrafterId != 0;
 
-        public double MaxDurability => SharedData.MaxDurability + Math.Max(0, Quality - 1) * SharedData.DurabilityPerLevel;
+        public double MaxDurability => SharedData == null ? 0d : SharedData.MaxDurability + Math.Max(0, Quality - 1) * SharedData.DurabilityPerLevel;
   
 
         public Item(string name, int stack, float durability, Vector2i pos, bool equiped, int quality, int variant, long crafterId, string crafterName, List<(string, string)> itemData)


### PR DESCRIPTION
This will at least prevent Loki from crashing but maybe there are better ways of solving this. This would fix the error reported in https://github.com/Wufflez/Loki/issues/30 (as in prevent Loki from crashing when unsupported items are in inventory. I have separate PR to add those missing items)

Another thought: I'd like to insert the actual internal game id (ie name) of the item in the inventory slot, instead of the fallback value 'item_name'. That way you can see what the name is that is missing, to be added in the SharedItemData DB. WPF is not my expertise so I don't know how to make a fallback that use the name of an item. Well, you could replace "item_data" with the item.name in code but that seems backwards...