### PR TITLE
Local Character file location

### DIFF
--- a/Loki/CharacterFile.cs
+++ b/Loki/CharacterFile.cs
@@ -51,7 +51,7 @@ namespace Loki
         public static CharacterFile[] LoadCharacterFiles()
         {
             string localLowPath = Shell32.GetKnownFolderPath(Shell32.LocalLowId);
-            string charactersPath = Path.Join(localLowPath, @"IronGate\Valheim\characters");
+            string charactersPath = Path.Join(localLowPath, @"IronGate\Valheim\characters_local");
             return Directory.EnumerateFiles(charactersPath, "*.fch").Select(FromPath).ToArray();
         }
 


### PR DESCRIPTION
Changed character location to "IronGate\Valheim\characters_local".
Addresses missing character listing, however requires user to have character save method set to local instead of cloud.